### PR TITLE
-- [CNX] added config flag  <hold_button_always_enabled>

### DIFF
--- a/docs/docs/feature-library/conference.md
+++ b/docs/docs/feature-library/conference.md
@@ -24,6 +24,7 @@ Within your `ui_attributes` file, the `conference` feature has 3 settings you ma
 
 - `enabled` - whether any functionality from this feature is enabled
 - `hold_workaround` - without the hold workaround, after a third participant is added to the conference while the caller is on hold, the entire conference will end if the caller hangs up. when the workaround is enabled, the customer will be taken off hold briefly when the third participant is added, then placed back on hold. This workaround allows the caller to later disconnect without ending the entire conference.
+- `hold_always_enabled` - [CNX] Normally, the hold button gets disabled when you start a transfer. This little workaround keeps it always on, no matter what.
 
 ### Outbound Call Configuration
 

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -73,7 +73,8 @@
       },
       "conference": {
         "enabled": true,
-        "hold_workaround": false
+        "hold_workaround": true,
+        "hold_button_always_enabled": true
       },
       "enhanced_crm_container": {
         "enabled": true,

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -73,8 +73,8 @@
       },
       "conference": {
         "enabled": true,
-        "hold_workaround": true,
-        "hold_button_always_enabled": true
+        "hold_workaround": false,
+        "hold_button_always_enabled": false
       },
       "enhanced_crm_container": {
         "enabled": true,

--- a/flex-config/ui_attributes.example.json
+++ b/flex-config/ui_attributes.example.json
@@ -1,6 +1,5 @@
 {
   "custom_data": {
-    "features": {
-    }
+    "features": {}
   }
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
@@ -1,7 +1,7 @@
 import { getFeatureFlags, getFlexFeatureFlag } from '../../utils/configuration';
 import ConferenceConfig from './types/ServiceConfiguration';
 
-const { enabled = false, hold_workaround = false } =
+const { enabled = false, hold_workaround = false, hold_button_always_enabled = false } =
   (getFeatureFlags()?.features?.conference as ConferenceConfig) || {};
 
 const nativeXwtEnabled = getFlexFeatureFlag('external-warm-transfers');
@@ -16,4 +16,8 @@ export const isConferenceEnabledWithoutNativeXWT = () => {
 
 export const isHoldWorkaroundEnabled = () => {
   return enabled && hold_workaround;
+};
+
+export const isHoldButtonAlwaysEnabled = () => {
+  return enabled && hold_button_always_enabled;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
@@ -12,6 +12,8 @@ import {
 
 import AppState from '../../../../types/manager/AppState';
 import { StringTemplates } from '../../flex-hooks/strings/Conference';
+import { isHoldButtonAlwaysEnabled } from '../../config';
+
 
 interface ThemeOnlyProps {
   theme?: any;
@@ -138,7 +140,7 @@ const ParticipantActionsButtons = (props: OwnProps) => {
       : templates[StringTemplates.HoldParticipant]();
     const kickParticipantTooltip = templates[StringTemplates.RemoveParticipant]();
 
-    const holdIcon = 'Hold';
+    const holdIcon = 'HoldBold';
     const unholdIcon = 'HoldOff';
 
     return (
@@ -146,7 +148,8 @@ const ParticipantActionsButtons = (props: OwnProps) => {
         <IconButton
           icon={participant.onHold ? `${unholdIcon}` : `${holdIcon}`}
           className="ParticipantCanvas-HoldButton"
-          disabled={!TaskHelper.canHold(task) || participant.status !== 'joined'}
+          //[CNX] added config to validate holdbutton enablement
+          disabled={!isHoldButtonAlwaysEnabled() && (!TaskHelper.canHold(task) || participant.status !== 'joined')}
           onClick={onHoldParticipantClick}
           variant="secondary"
           title={holdParticipantTooltip}

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
@@ -1,7 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 
 import ProgrammableVoiceService from '../../../../utils/serverless/ProgrammableVoice/ProgrammableVoiceService';
-import { isConferenceEnabledWithoutNativeXWT } from '../../config';
+import { isConferenceEnabledWithoutNativeXWT,isHoldButtonAlwaysEnabled } from '../../config';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 import logger from '../../../../utils/logger';
 
@@ -13,7 +13,8 @@ export const actionHook = function handleHoldConferenceParticipant(flex: typeof 
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
     const { participantType, targetSid: participantSid, task } = payload;
 
-    if (participantType !== 'unknown') {
+    //[CNX] added config to validate holdbutton enablement
+    if (!isHoldButtonAlwaysEnabled() && participantType !== 'unknown') {
       return;
     }
 

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/UnholdParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/UnholdParticipant.ts
@@ -1,7 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 
 import ProgrammableVoiceService from '../../../../utils/serverless/ProgrammableVoice/ProgrammableVoiceService';
-import { isConferenceEnabledWithoutNativeXWT } from '../../config';
+import { isConferenceEnabledWithoutNativeXWT,isHoldButtonAlwaysEnabled } from '../../config';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 import logger from '../../../../utils/logger';
 
@@ -12,8 +12,9 @@ export const actionHook = function handleUnholdConferenceParticipant(flex: typeo
 
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
     const { participantType, targetSid: participantSid, task } = payload;
-
-    if (participantType !== 'unknown') {
+    
+     //[CNX] added config to validate holdbutton enablement
+     if (!isHoldButtonAlwaysEnabled() && participantType !== 'unknown') {
       return;
     }
 

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/types/ServiceConfiguration.ts
@@ -1,4 +1,5 @@
 export default interface ConferenceConfig {
   enabled: boolean;
   hold_workaround: boolean;
+  hold_button_always_enabled: boolean;
 }


### PR DESCRIPTION
### Summary

Added config flag <hold_button_always_enabled> and logic to validate is the hold button will always be enabled in the call.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
